### PR TITLE
add auto unloading

### DIFF
--- a/options.html
+++ b/options.html
@@ -54,6 +54,10 @@
     <label for="timeLimit">Close tabs after (minutes):</label>
     <input type="number" id="timeLimit" min="1" value="30">
   </div>
+  <div class="form-group">
+    <label for="unloadTimeout">Unload all tabs every (minutes):</label>
+    <input type="number" id="unloadTimeout" min="1" value="30">
+  </div>
 
   <div class="form-group">
     <label for="whitelist">Whitelist Patterns (one per line):</label>

--- a/options.js
+++ b/options.js
@@ -3,11 +3,13 @@ function saveOptions(e) {
   e.preventDefault();
   console.log('Saving options...');
   const timeLimit = document.getElementById('timeLimit').value;
+  const unloadTimeout = document.getElementById('unloadTimeout').value;
   const whitelist = document.getElementById('whitelist').value.split('\n').filter(pattern => pattern.trim() !== '');
-  console.log('New settings:', { timeLimit, whitelist });
+  console.log('New settings:', { timeLimit, unloadTimeout, whitelist });
   browser.storage.sync.set({
-    timeLimit: document.getElementById('timeLimit').value,
-    whitelist: document.getElementById('whitelist').value.split('\n').filter(pattern => pattern.trim() !== '')
+    timeLimit: timeLimit,
+    unloadTimeout: unloadTimeout,
+    whitelist: whitelist
   }).then(() => {
     const status = document.getElementById('status');
     status.textContent = 'Settings saved successfully!';
@@ -24,10 +26,12 @@ function restoreOptions() {
   console.log('Loading saved options...');
   browser.storage.sync.get({
     timeLimit: 1,
+    unloadTimeout: 30,
     whitelist: []
   }).then((result) => {
     console.log('Loaded settings:', result);
     document.getElementById('timeLimit').value = result.timeLimit;
+    document.getElementById('unloadTimeout').value = result.unloadTimeout;
     document.getElementById('whitelist').value = result.whitelist.join('\n');
   }).catch(error => {
     console.error('Error loading settings:', error);

--- a/popup.html
+++ b/popup.html
@@ -47,19 +47,21 @@
     }
 
     body {
-      width: 400px;
-      padding: 20px;
+      width: 350px;
+      padding: 12px;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
       color: var(--text-color);
       background-color: var(--bg-color);
-      line-height: 1.5;
+      line-height: 1.4;
+      font-size: 13px;
     }
 
     .header {
       display: flex;
       align-items: center;
-      margin-bottom: 20px;
-      padding-bottom: 12px;
+      justify-content: space-between;
+      margin-bottom: 12px;
+      padding-bottom: 8px;
       border-bottom: 1px solid var(--border-color);
     }
 
@@ -71,9 +73,9 @@
     }
 
     .section {
-      margin-bottom: 24px;
+      margin-bottom: 12px;
       background: var(--bg-light);
-      padding: 16px;
+      padding: 10px;
       border-radius: var(--radius);
       box-shadow: var(--shadow);
     }
@@ -98,7 +100,7 @@
     }
 
     .form-group {
-      margin-bottom: 16px;
+      margin-bottom: 6px;
     }
 
     label {
@@ -322,15 +324,8 @@
     }
 
     button {
-      padding: 10px 16px;
-      background: var(--primary-color);
-      color: white;
-      border: none;
-      border-radius: var(--radius);
-      cursor: pointer;
-      font-weight: 500;
-      transition: var(--transition);
-      font-size: 14px;
+      padding: 5px 10px;
+      font-size: 12px;
     }
 
     button:hover {
@@ -339,8 +334,8 @@
 
     .button-group {
       display: flex;
-      gap: 10px;
-      margin-top: 16px;
+      gap: 6px;
+      margin-top: 6px;
     }
 
     #status {
@@ -429,12 +424,27 @@
       <input type="number" id="timeLimit" min="1" max="1440" value="2" required>
     </div>
     <div class="form-group">
+      <label for="unloadTimeout">Unload all tabs every (minutes):</label>
+      <input type="number" id="unloadTimeout" min="1" max="1440" value="30" required>
+    </div>
+    <div class="form-group">
+      <label class="toggle-switch">
+        <input type="checkbox" id="autoKillUnloaded" checked>
+        <span class="toggle-slider"></span>
+        <span class="toggle-label">Auto-kill unloaded tabs after 24 hours</span>
+      </label>
+    </div>
+    <div class="form-group">
       <label>Notification Settings:</label>
       <div class="checkbox-group">
         <label>
           <input type="checkbox" id="showNotifications" checked> Show notifications when tabs are closed
         </label>
       </div>
+    </div>
+    <div class="button-group">
+      <button id="unloadInactive" class="secondary">Unload Inactive Tabs</button>
+      <button id="saveSettings">Save Settings</button>
     </div>
   </div>
 


### PR DESCRIPTION
- Add toggle setting to enable/disable auto-kill feature
- Implement 24-hour auto-kill for unloaded tabs
- Track unloaded tabs with timestamps
- Add periodic check (every 30 mins) for old unloaded tabs
- Update history to show killed tabs
- Add console logging for debugging
- Clean up tab tracking when tabs become active

This change helps manage memory usage by automatically closing tabs that have been unloaded for 24 hours, while giving users control over this behavior through a new setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to automatically unload inactive tabs after a user-defined interval.
  - Introduced an option to auto-kill tabs that have been unloaded for over 24 hours.
  - Added manual control to unload inactive tabs via a button in the popup.
  - Enhanced settings in both the popup and options pages to configure unload intervals and auto-kill behavior.

- **Improvements**
  - Updated closed tabs history to show whether a tab was closed or unloaded, with a simplified and more compact display.
  - Refined the popup UI for a smaller, cleaner appearance and improved usability.

- **Bug Fixes**
  - Improved tracking and management of unloaded tabs to ensure accurate notifications and actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->