### PR TITLE
Fix: Ensure your configuration is respected

### DIFF
--- a/options.html
+++ b/options.html
@@ -52,7 +52,7 @@
   
   <div class="form-group">
     <label for="timeLimit">Close tabs after (minutes):</label>
-    <input type="number" id="timeLimit" min="1" value="30">
+    <input type="number" id="timeLimit" min="1" value="2">
   </div>
   <div class="form-group">
     <label for="unloadTimeout">Unload all tabs every (minutes):</label>

--- a/options.js
+++ b/options.js
@@ -25,7 +25,7 @@ function saveOptions(e) {
 function restoreOptions() {
   console.log('Loading saved options...');
   browser.storage.sync.get({
-    timeLimit: 1,
+    timeLimit: 2, // Default to 2 minutes, consistent with config.json and background.js
     unloadTimeout: 30,
     whitelist: []
   }).then((result) => {


### PR DESCRIPTION
This commit addresses issues where your defined settings, particularly 'unloadTimeout' and 'whitelist', were not being consistently applied.

Key changes:
- Corrected `unloadTimeout` setting to be consistently read from `browser.storage.sync` across all relevant functions in `background.js`, ensuring the value you set in options is used.
- Integrated your defined `whitelist` patterns from options into the core tab management logic in `background.js`. Whitelist URL strings are now transformed into pattern objects with an 'action: keep' and are prioritized.
- Removed a redundant `checkUnloadTabs` function from `background.js` to reduce confusion and potential bugs.
- Aligned the default `timeLimit` value across `options.js`, `options.html`, and `background.js` for better consistency if settings haven't been saved by you yet.

These changes should ensure that the extension more reliably adheres to your configured preferences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Whitelisted sites are now integrated into tab inactivity checks, ensuring specified sites are always kept active.

- **Bug Fixes**
	- Updated storage handling for settings to improve consistency and reliability.

- **Style**
	- Changed the default value for "Close tabs after (minutes)" in settings from 30 to 2 minutes for new users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->